### PR TITLE
Fixing vultr.com link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vultr Dynamic DNS
 
-### Use [vultr.com](vultr.com)'s free DNS hosting as your own free private dynamic DNS provider - **using any TLD you own!**
+### Use [vultr.com](https://www.vultr.com/)'s free DNS hosting as your own free private dynamic DNS provider - **using any TLD you own!**
 
 ---
 


### PR DESCRIPTION
Link was broken as it was missing http/https:// and was directing people to https://github.com/se1exin/Vultr-Dynamic-DNS/blob/master/vultr.com
